### PR TITLE
Pre-commit config updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,8 +52,25 @@ repos:
     rev: main
     hooks:
       - id: build-docs
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: copyright
-      # - id: package-app-dependencies
-      # - id: notice-file
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
+      - id: package-app-dependencies
+        language: python
+        additional_dependencies: ["local-hooks"]
+      - id: notice-file
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: release-notes
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: static-tests
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* fix: Workflow file updates
+* chore(ci): Pre-commit config updates


### PR DESCRIPTION
- Enable package_app_dependency pre-commit hook
- Enable generate_notice pre-commit hook
- All pre-commit hooks besides package_app_dependencies now require args
- Workflow file updates

[_Created by Sourcegraph batch change `mnordby-splunk/003-pre-commit-updates`._](https://sourcegraph.splunkdev.net/users/mnordby-splunk/batch-changes/003-pre-commit-updates)